### PR TITLE
Fix dialog button not displaying correctly

### DIFF
--- a/src/PureModalAction.php
+++ b/src/PureModalAction.php
@@ -83,7 +83,7 @@ class PureModalAction extends DatalessField
      */
     protected function getDialogButtonTitle()
     {
-        $title = $this->buttonTitle ?: $this->title;
+        $title = $this->dialogButtonTitle ?: $this->title;
         if ($this->buttonIcon) {
             $title = '<span class="font-icon-' . $this->buttonIcon . '"></span> ' . $title;
         }
@@ -97,7 +97,7 @@ class PureModalAction extends DatalessField
      */
     public function setDialogButtonTitle($value)
     {
-        $this->buttonTitle = $value;
+        $this->dialogButtonTitle = $value;
         return $this;
     }
 

--- a/templates/LeKoala/PureModal/PureModalAction.ss
+++ b/templates/LeKoala/PureModal/PureModalAction.ss
@@ -21,7 +21,9 @@
             </div>
             <% if $ShowDialogButton %>
                 <div class="toolbar toolbar--south">
-                    <input type="submit" name="action_$Name" class="btn action btn btn-info custom-action" value="$ButtonTitle">
+                    <button type="submit" name="action_$Name" class="action custom-action<% if $extraClass %> $extraClass<% end_if %>">
+                        {$DialogButtonTitle.RAW}
+                    </button>
                 </div>
             <% end_if %>
         </div>


### PR DESCRIPTION
Fixes the following issues:

- Dialog button didn’t show the text set with `->setDialogButtonTitle()`, it would always show the main button title
- If an icon was set on the main button, it would show as escaped HTML on the dialog button
- If a button type was set on the main button, it wouldn’t show on the dialog button